### PR TITLE
Aps/text key error fix

### DIFF
--- a/api/scholarqa/postprocess/json_output_utils.py
+++ b/api/scholarqa/postprocess/json_output_utils.py
@@ -49,9 +49,11 @@ def get_section_text(gen_text: str) -> Dict[str, Any]:
             else:
                 text = parts[1].strip()
             curr_section["text"] = text
+        else:
+            raise Exception("Invalid content generated for the query by the LLM")
     except Exception as e:
         logger.exception(f"Error while parsing llm gen text: {gen_text} - {e}")
-        raise Exception("Error while parsing llm generated text")
+        raise e
 
     return curr_section
 

--- a/api/scholarqa/postprocess/json_output_utils.py
+++ b/api/scholarqa/postprocess/json_output_utils.py
@@ -39,7 +39,6 @@ def get_section_text(gen_text: str) -> Dict[str, Any]:
             title = parts[0].strip()
             title = re.sub(r"\s*\(list\)", "", title)
             title = re.sub(r"\s*\(synthesis\)", "", title)
-            curr_section = dict()
             curr_section["title"] = title.strip('#').strip()
             if tldr_token is not None:
                 text_parts = parts[1].strip().split("\n", 1)


### PR DESCRIPTION
Fix for the case where the model generates text without any TLDR and hence cannot be parsed.

Exception text:
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/ed90e1fa-bcb5-49c4-8d30-e0f842134fbf" />


Post fix (it's from my local demo instance, but would translate to derived systems too):
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/cde52b5e-40c1-40df-92fe-c51c6713155a" />

