### PR TITLE
Restricted abstracts based on open access flags

### DIFF
--- a/api/scholarqa/postprocess/json_output_utils.py
+++ b/api/scholarqa/postprocess/json_output_utils.py
@@ -72,6 +72,12 @@ def pop_ref_data(ref_str_id, ref_corpus_id, fixed_quote, curr_paper_metadata) ->
     curr_ref["paper"] = dict()
     curr_ref["paper"]["corpus_id"] = make_int(ref_corpus_id)
     if curr_paper_metadata:
+        if not (curr_paper_metadata.get("isOpenAccess") and curr_paper_metadata.get("openAccessPdf")):
+            curr_ref["snippets"] = [s for s in curr_ref["snippets"] if
+                                    s[:20] not in curr_paper_metadata.get("abstract", "")]
+            if not curr_ref["snippets"]:
+                curr_ref["snippets"] = ["Please click on the paper title to read the abstract on Semantic Scholar."]
+
         curr_ref["score"] = curr_paper_metadata.get("relevance_judgement", 0)
         curr_ref["paper"]["title"] = curr_paper_metadata["title"]
         curr_ref["paper"]["authors"] = curr_paper_metadata["authors"]

--- a/api/scholarqa/utils.py
+++ b/api/scholarqa/utils.py
@@ -20,7 +20,7 @@ S2_API_BASE_URL = "https://api.semanticscholar.org/graph/v1/"
 CompletionResult = namedtuple("CompletionCost",
                               ["content", "model", "cost", "input_tokens", "output_tokens", "total_tokens"])
 NUMERIC_META_FIELDS = {"year", "citationCount", "referenceCount", "influentialCitationCount"}
-CATEGORICAL_META_FIELDS = {"title", "abstract", "corpusId", "authors", "venue"}
+CATEGORICAL_META_FIELDS = {"title", "abstract", "corpusId", "authors", "venue", "isOpenAccess", "openAccessPdf"}
 METADATA_FIELDS = ",".join(CATEGORICAL_META_FIELDS.union(NUMERIC_META_FIELDS))
 
 


### PR DESCRIPTION
Restrict abstracts in the citation cards based on open access checks:

IEEE abstract - 
<img width="1222" alt="image" src="https://github.com/user-attachments/assets/a12fecc3-fe8c-47ad-9780-bd53e2373d3d" />

Other evidence unaffected - 
<img width="961" alt="image" src="https://github.com/user-attachments/assets/472f5514-79cc-4068-b87c-01a5c2ff0ada" />
