### PR TITLE
unicode to ascii in citation fix

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 #Help generate the rest of the file
 name = "ai2-scholar-qa"
-version = "0.5.19"
+version = "0.5.20"
 readme = "README.md"
 license = {text = 'Apache-2.0'}
 description = "Python package to embed the Ai2 Scholar QA functionality in another application"
@@ -41,7 +41,8 @@ dependencies = [
     "litellm==1.51.3",
     "pandas==2.2.2",
     "diskcache==5.6.3",
-    "langsmith==0.1.140"
+    "langsmith==0.1.140",
+    "anyascii==0.3.2"
 ]
 [project.optional-dependencies]
 dev = [

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -26,3 +26,4 @@ litellm==1.51.3
 pandas==2.2.2
 diskcache==5.6.3
 langsmith==0.1.140
+anyascii==0.3.2

--- a/api/scholarqa/postprocess/json_output_utils.py
+++ b/api/scholarqa/postprocess/json_output_utils.py
@@ -152,6 +152,7 @@ def get_json_summary(llm_model: str, summary_sections: List[str], summary_quotes
                         refs_list.append(ref_data)
                 else:
                     curr_section["text"] = curr_section["text"].replace(ref, "")
+                    logger.warning(f"Reference not found in the summary quotes: {ref}")
             curr_section["text"] = re.sub(r"[ ]+", " ", curr_section["text"])
             # curr_section["text"] = curr_section["text"].replace(") ; (", "]; [")
             curr_section["citations"] = refs_list

--- a/api/scholarqa/postprocess/json_output_utils.py
+++ b/api/scholarqa/postprocess/json_output_utils.py
@@ -3,6 +3,7 @@ from typing import Optional, Dict, Any, List
 from scholarqa.utils import make_int
 from langsmith import traceable
 import logging
+from anyascii import anyascii
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +123,7 @@ def get_json_summary(llm_model: str, summary_sections: List[str], summary_quotes
             refs_done = set()
 
             for ref in references:
+                ref = anyascii(ref)
                 if ref in summary_quotes or ref in inline_citation_quotes:
                     ref_parts = ref[1:-1].split(" | ")
                     ref_corpus_id, ref_str = ref_parts[0], f"({ref_parts[1]}, {make_int(ref_parts[2])})".replace(
@@ -148,6 +150,9 @@ def get_json_summary(llm_model: str, summary_sections: List[str], summary_quotes
                         else:
                             curr_section["text"] = curr_section["text"].replace(ref, ref_data["id"])
                         refs_list.append(ref_data)
+                else:
+                    curr_section["text"] = curr_section["text"].replace(ref, "")
+            curr_section["text"] = re.sub(r"[ ]+", " ", curr_section["text"])
             # curr_section["text"] = curr_section["text"].replace(") ; (", "]; [")
             curr_section["citations"] = refs_list
             # add number of unique citations to section tldr

--- a/api/scholarqa/rag/multi_step_qa_pipeline.py
+++ b/api/scholarqa/rag/multi_step_qa_pipeline.py
@@ -13,6 +13,7 @@ from scholarqa.llms.litellm_helper import batch_llm_completion, llm_completion
 from scholarqa.llms.prompts import USER_PROMPT_PAPER_LIST_FORMAT, USER_PROMPT_QUOTE_LIST_FORMAT, \
     PROMPT_ASSEMBLE_NO_QUOTES_SUMMARY
 from scholarqa.utils import CompletionResult, get_ref_author_str, make_int, get_paper_metadata
+from anyascii import anyascii
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +203,7 @@ class MultiStepQAPipeline:
                                                                         f"{get_ref_author_str(mdata['authors'])} | "
                                                                         f"{make_int(mdata.get('year'))} "
                                                                         f"| Citations: {make_int(mdata['citationCount'])}]")
+                mref_str = anyascii(mref_str)
                 per_paper_summaries[ref_str]["quote"] = per_paper_summaries[ref_str]["quote"].replace(
                     f"({mdata['corpusId']})",
                     f"({get_ref_author_str(mdata['authors'])}, {make_int(mdata.get('year'))})")

--- a/api/scholarqa/rag/retrieval.py
+++ b/api/scholarqa/rag/retrieval.py
@@ -7,6 +7,7 @@ import pandas as pd
 from scholarqa.rag.reranker.reranker_base import AbstractReranker
 from scholarqa.rag.retriever_base import AbstractRetriever
 from scholarqa.utils import make_int, get_ref_author_str
+from anyascii import anyascii
 
 logger = logging.getLogger(__name__)
 
@@ -135,8 +136,8 @@ class PaperFinder(AbsPaperFinder):
         df.loc[:, "relevance_judgment_input_expanded"] = prepend_text + section_text
         df["reference_string"] = df.apply(
             lambda
-                row: f"[{make_int(row.corpus_id)} | {get_ref_author_str(row.authors)} | "
-                     f"{make_int(row['year'])} | Citations: {make_int(row['citation_count'])}]",
+                row: anyascii(f"[{make_int(row.corpus_id)} | {get_ref_author_str(row.authors)} | "
+                     f"{make_int(row['year'])} | Citations: {make_int(row['citation_count'])}]"),
             axis=1,
         )
         return df


### PR DESCRIPTION
Issue: We do string matching for  citation mention in the LLM generation with the keys created from the metadata i.e. [Corpus id, Author, year, # of citations], in this particular example the author name had the unicode single quote so string matching didn't work.
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/761b6d79-e79e-4062-bfe2-cecb159657ce" />

Added following handling for this - 
i. anyascii package - ISC license, should be allowed
ii. Both the in program keys and the generated refs are converted to ascii before matching
iii. If no match found, replace the generated citation mention with blank string with added logging for analysis

Post fix:
<img width="1064" alt="image" src="https://github.com/user-attachments/assets/85032f3a-44c9-4349-afad-a999d1b3c5fb" />
