### PR TITLE
Drop paperId in the aggregate snippets step

### DIFF
--- a/api/scholarqa/rag/retrieval.py
+++ b/api/scholarqa/rag/retrieval.py
@@ -62,8 +62,6 @@ class PaperFinder(AbsPaperFinder):
                 paper_snippets[corpus_id]["sentences"].append(snippet)
             if "paperId" in paper_snippets[corpus_id]:
                 del paper_snippets[corpus_id]["paperId"]
-            if "paperId" in snippet:
-                del snippet["paperId"]
             paper_snippets[corpus_id]["relevance_judgement"] = max(
                 paper_snippets[corpus_id].get("relevance_judgement", -1),
                 snippet.get("rerank_score", snippet["score"]))

--- a/api/scholarqa/rag/retrieval.py
+++ b/api/scholarqa/rag/retrieval.py
@@ -60,6 +60,8 @@ class PaperFinder(AbsPaperFinder):
                 paper_snippets[corpus_id]["sentences"] = []
             if snippet["stype"] != "public_api":
                 paper_snippets[corpus_id]["sentences"].append(snippet)
+            if "paperId" in paper_snippets[corpus_id]:
+                del paper_snippets[corpus_id]["paperId"]
             paper_snippets[corpus_id]["relevance_judgement"] = max(
                 paper_snippets[corpus_id].get("relevance_judgement", -1),
                 snippet.get("rerank_score", snippet["score"]))
@@ -121,8 +123,8 @@ class PaperFinder(AbsPaperFinder):
             inplace=True,
         )
 
-        # drop corpusId, paperId,
-        df = df.drop(columns=["corpusId", "paperId"])
+        # drop corpusId
+        df = df.drop(columns=["corpusId"])
 
         # now we need the big relevance_judgment_input_expanded
         # top of it

--- a/api/scholarqa/rag/retrieval.py
+++ b/api/scholarqa/rag/retrieval.py
@@ -62,6 +62,8 @@ class PaperFinder(AbsPaperFinder):
                 paper_snippets[corpus_id]["sentences"].append(snippet)
             if "paperId" in paper_snippets[corpus_id]:
                 del paper_snippets[corpus_id]["paperId"]
+            if "paperId" in snippet:
+                del snippet["paperId"]
             paper_snippets[corpus_id]["relevance_judgement"] = max(
                 paper_snippets[corpus_id].get("relevance_judgement", -1),
                 snippet.get("rerank_score", snippet["score"]))


### PR DESCRIPTION
Drop `paperId` in the snippet aggregation step. We only need `corpus_id`.