### PR TITLE
dont use tqdm

### DIFF
--- a/api/scholarqa/rag/multi_step_qa_pipeline.py
+++ b/api/scholarqa/rag/multi_step_qa_pipeline.py
@@ -237,7 +237,7 @@ class MultiStepQAPipeline:
         plan_str = "\n".join([k for k in plan])
         existing_sections = []
         i = 0
-        for section_name, inds in tqdm(plan.items()):
+        for section_name, inds in plan.items():
             # inds are a string like this: "[1, 2, 3]"
             # get the quotes for each index
             quotes = ""

--- a/api/scholarqa/scholar_qa.py
+++ b/api/scholarqa/scholar_qa.py
@@ -374,7 +374,7 @@ class ScholarQA:
                                step_estimated_time=20)
 
         start = time()
-        for tthread in tqdm(table_threads):
+        for tthread in table_threads:
             tthread.join()
         logger.info(f"Adhoc Table generation wait time: {time() - start:.2f}")
 


### PR DESCRIPTION
I'm happy to add a kwarg flag to enable or disable tqdm use instead if you want. I've removed it here though since it causes some downstream os dependent issues. (it's possible that we could fix it by asking multiprocessing to use spawn instead of fork or something like that, but I'd really rather not go down that rabbit hole at the moment)