### PR TITLE
Aps/litellm upgrade

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 #Help generate the rest of the file
 name = "ai2-scholar-qa"
-version = "0.6.4"
+version = "0.6.5"
 readme = "README.md"
 license = {text = 'Apache-2.0'}
 description = "Python package to embed the Ai2 Scholar QA functionality in another application"
@@ -39,7 +39,7 @@ dependencies = [
     "tqdm",
     "google-cloud-storage==2.18.2",
     "filelock==3.16.1",
-    "litellm==1.52.0",
+    "litellm==1.68.0",
     "pandas==2.2.2",
     "diskcache==5.6.3",
     "langsmith==0.1.142",

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -22,7 +22,7 @@ openai==1.69.0
 tqdm
 google-cloud-storage==2.18.2
 filelock==3.16.1
-litellm==1.51.3
+litellm==1.68.0
 pandas==2.2.2
 diskcache==5.6.3
 langsmith==0.1.140

--- a/api/scholarqa/llms/litellm_helper.py
+++ b/api/scholarqa/llms/litellm_helper.py
@@ -69,7 +69,7 @@ def batch_llm_completion(model: str, messages: List[str], system_prompt: str = N
     fallbacks = [fallback] if fallback else []
     messages = [trim_messages([{"role": "system", "content": system_prompt}, {"role": "user", "content": msg}], model)
                 for msg in messages]
-    responses = litellm.batch_completion(messages=messages, model=model, fallbacks=fallbacks, **llm_lite_params)
+    responses = litellm.batch_completion(messages=messages, model=model, **llm_lite_params)
     results = []
     for i, res in enumerate(responses):
         try:
@@ -96,7 +96,7 @@ def llm_completion(user_prompt: str, system_prompt: str = None, fallback=GPT_4o,
     if system_prompt:
         messages.append({"role": "system", "content": system_prompt})
     messages.append({"role": "user", "content": user_prompt})
-    response = litellm.completion(messages=messages, fallbacks=fallbacks, **llm_lite_params)
+    response = litellm.completion(messages=messages, **llm_lite_params)
     try:
         res_cost = round(litellm.completion_cost(response), 6)
     except Exception as e:

--- a/api/scholarqa/llms/litellm_helper.py
+++ b/api/scholarqa/llms/litellm_helper.py
@@ -66,7 +66,7 @@ def batch_llm_completion(model: str, messages: List[str], system_prompt: str = N
                          **llm_lite_params) -> List[
     CompletionResult]:
     """returns the result from the llm chat completion api with cost and tokens used"""
-    fallbacks = [fallback] if fallback else []
+    fallbacks = [fallback] if fallback else [] #Disable for now in lieu of https://github.com/BerriAI/litellm/issues/10517
     messages = [trim_messages([{"role": "system", "content": system_prompt}, {"role": "user", "content": msg}], model)
                 for msg in messages]
     responses = litellm.batch_completion(messages=messages, model=model, **llm_lite_params)
@@ -92,7 +92,7 @@ def batch_llm_completion(model: str, messages: List[str], system_prompt: str = N
 def llm_completion(user_prompt: str, system_prompt: str = None, fallback=GPT_4o, **llm_lite_params) -> CompletionResult:
     """returns the result from the llm chat completion api with cost and tokens used"""
     messages = []
-    fallbacks = [fallback] if fallback else []
+    fallbacks = [fallback] if fallback else [] #Disable for now in lieu of https://github.com/BerriAI/litellm/issues/10517
     if system_prompt:
         messages.append({"role": "system", "content": system_prompt})
     messages.append({"role": "user", "content": user_prompt})

--- a/api/scholarqa/llms/prompts.py
+++ b/api/scholarqa/llms/prompts.py
@@ -78,7 +78,8 @@ The last thing you output is an assignment of each quote to a dimension like so:
 {{"name": "dimension name 3", "format": "synthesis or list", "quotes": []}},  # empty because we didn't find any supporting quotes
 ...
 ]
-}} 
+}}
+Dont add unnecessary linebreaks or spaces to the output.
 """
 
 USER_PROMPT_QUERY_FORMAT = """


### PR DESCRIPTION
I was hesitant to upgrade the litellm version in lieu of the async processing errors here: https://github.com/BerriAI/litellm/issues/10517. However, openai introduced breaking changes to older litellm versions as noted here - https://github.com/BerriAI/litellm/issues/9424.
Pinning the openai version to 1.61.0 worked (that's what we have in production), however for our benchmarking tool the minimum required version for openai is 1.69.0.

After debugging, the async processing errors were found to be connected to using the litellm provided fallback mechanism. So, after discussing with @gituser768 (Dany), we decided to have the upgraded version without fallback for the library and eval, while production can keep using the older version.

FYI @sergeyf 
