### PR TITLE
max date resolve if present for keyword search

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 #Help generate the rest of the file
 name = "ai2-scholar-qa"
-version = "0.6.5"
+version = "0.6.6"
 readme = "README.md"
 license = {text = 'Apache-2.0'}
 description = "Python package to embed the Ai2 Scholar QA functionality in another application"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 #Help generate the rest of the file
 name = "ai2-scholar-qa"
-version = "0.6.6"
+version = "0.6.7"
 readme = "README.md"
 license = {text = 'Apache-2.0'}
 description = "Python package to embed the Ai2 Scholar QA functionality in another application"

--- a/api/scholarqa/rag/retrieval.py
+++ b/api/scholarqa/rag/retrieval.py
@@ -47,8 +47,7 @@ class PaperFinder(AbsPaperFinder):
                 date_start, date_end = year_filter.split("-") # YYYY-YYYY
                 max_year = self.max_date.split("-")[0] #YYYY-MM
                 # restrict both start and end to max_year and if end is max_year, set it to max_date
-                date_start, date_end = min(date_start, max_year), min(date_end,
-                                                                      max_year) if date_end != max_year else self.max_date
+                date_start, date_end = min(date_start, max_year), date_end if date_end and date_end < max_year else self.max_date
                 filter_kwargs.update({"publicationDateOrYear": '{}:{}'.format(date_start, date_end)})
 
             else:


### PR DESCRIPTION
Here's the story:
insertion date criteria is used to restrict the papers returned from the snippet/search index end point.
To achieve the same for keyword search, the `publicationDateOrYear` param was used with the insertion date value.
However, in cases where the query decomposer also resolves the query into a span of years, the api search end point cannot handle both the `publicationDateOrYear` and `year` params.
Case in point, the query: Teach me about all **latest** progress on diagnosis, such as counterfactual explanation, of VLM models like CLIP
The LLM resolves the expected retrieval for this to years 2022-2025.
This results in the params `year`= 2022-2025 and `publicationDateOrYear` = :2025-05 being sent to keyword search.

Result:
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/fcb4142f-9c44-4f8c-b525-8cf01184eb25" />

Replacing the year in such cases with the insertion. date would not be the right solution as the query might require papers only from a time span prior to the insertion date e.g. 2022-2024.
So the solution implemented here is to resolve the start and end year of the spans if they exist to the smaller value between it and insertion year. In case insertion year and end year are the same, restrict to insertion date.
