### PR TITLE
Minor changes to table generator to make it optimal for astabench exps

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 #Help generate the rest of the file
 name = "ai2-scholar-qa"
-version = "0.6.8"
+version = "0.6.9"
 readme = "README.md"
 license = {text = 'Apache-2.0'}
 description = "Python package to embed the Ai2 Scholar QA functionality in another application"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 #Help generate the rest of the file
 name = "ai2-scholar-qa"
-version = "0.6.9"
+version = "0.6.10"
 readme = "README.md"
 license = {text = 'Apache-2.0'}
 description = "Python package to embed the Ai2 Scholar QA functionality in another application"

--- a/api/scholarqa/scholar_qa.py
+++ b/api/scholarqa/scholar_qa.py
@@ -406,7 +406,7 @@ class ScholarQA:
             logger.info(
                 "Received table generation request for topic: " + payload["section_title"]
             )
-            table = self.table_generator.run_table_generation(
+            table, costs = self.table_generator.run_table_generation(
                 thread_id=payload["task_id"],
                 user_id=payload["user_id"],
                 original_query=payload["query"],

--- a/api/scholarqa/table_generation/column_suggestion.py
+++ b/api/scholarqa/table_generation/column_suggestion.py
@@ -44,12 +44,12 @@ def format_paper_info(paper_info: Dict) -> str:
     return formatted_paper_info
 
 
-def generate_final_prompt(query: str, formatted_paper_info: str) -> str:
+def generate_final_prompt(query: str, formatted_paper_info: str, column_num: str) -> str:
     """
     Given the formatted paper information, and an optional user query,
     generate the final column suggestion prompt to be sent to the LLM.
     """
-    final_prompt = ATTRIBUTE_PROMPT.format(query, 10, formatted_paper_info)
+    final_prompt = ATTRIBUTE_PROMPT.format(query, column_num, formatted_paper_info)
     return final_prompt
 
 
@@ -57,6 +57,7 @@ def generate_attribute_suggestions(
         corpus_ids: List[str], 
         model: str = GPT_4o, 
         query: str = None,
+        column_num: int = 10,
         llm_caller: CostAwareLLMCaller = None,
         cost_args: CostReportingArgs = None,
     ) -> Dict:
@@ -74,7 +75,7 @@ def generate_attribute_suggestions(
     formatted_paper_info = format_paper_info(paper_info)
     
     # Step 4: Produce final column generation prompt from papers and user query
-    final_prompt = generate_final_prompt(user_query, formatted_paper_info)
+    final_prompt = generate_final_prompt(user_query, formatted_paper_info, column_num)
 
     # Step 5: Prompt the LLM to produce column suggestions
     column_suggestion_params = {

--- a/api/scholarqa/table_generation/table_generator.py
+++ b/api/scholarqa/table_generation/table_generator.py
@@ -31,6 +31,8 @@ class TableGenerator:
         original_query: str, 
         section_title: str, 
         corpus_ids: List[int],
+        column_num: int = 10,
+        run_subselection: bool = True,
         column_model: Optional[str] = GPT_4o,
         value_model: Optional[str] = GPT_4o,
     ) -> TableWidget:
@@ -44,7 +46,9 @@ class TableGenerator:
         # Step 1: Construct a query for the column suggestion tool using
         # the section title and original user query as input. Also create
         # a cost argument object to allow the the tool to track costs
-        column_suggestion_query = f"{section_title}, a section included in an answer to the question: {original_query}"
+        column_suggestion_query = f"{section_title}"
+        if original_query != "":
+            column_suggestion_query += f", a section included in an answer to the question: {original_query}"
         cost_args = CostReportingArgs(
             task_id=thread_id,
             user_id=user_id,
@@ -57,6 +61,7 @@ class TableGenerator:
             query=column_suggestion_query,
             model=column_model,
             llm_caller=self.llm_caller,
+            column_num=column_num,
         )
         
         # Step 2: Create a new table data structure with suggested columns.
@@ -122,7 +127,8 @@ class TableGenerator:
             ))
             table.cells = {k: v for d in new_cells for k, v in d.items()}
 
-        table = self.subselect_columns_and_rows(table)
+        if run_subselection:
+            table = self.subselect_columns_and_rows(table)
 
         return table
     

--- a/api/scholarqa/table_generation/value_generation.py
+++ b/api/scholarqa/table_generation/value_generation.py
@@ -192,7 +192,7 @@ def run_paper_qa(
                 "answer": json.loads(output.result.content)["answer"],
                 "corpusId": corpus_id,
                 "source": "vespa-snippets",
-                "evidenceId": json.loads(output.result.content)["exceprts"],
+                "evidenceId": json.loads(output.result.content).get("exceprts", []),
                 "cost": get_cost_object(output.result),
             }
             print(response_simplified)

--- a/api/scholarqa/table_generation/value_generation.py
+++ b/api/scholarqa/table_generation/value_generation.py
@@ -186,14 +186,16 @@ def run_paper_qa(
                 method=llm_completion,
                 **value_generation_params,
             )
+            print(json.loads(output.result.content))
             response_simplified = {
                 "question": question,
-                "answer": output.result.content,
+                "answer": json.loads(output.result.content)["answer"],
                 "corpusId": corpus_id,
                 "source": "vespa-snippets",
-                "evidenceId": None, # TODO: Figure out what to do here?
+                "evidenceId": json.loads(output.result.content)["exceprts"],
                 "cost": get_cost_object(output.result),
             }
+            print(response_simplified)
         else:
             response, cost = get_value_from_abstract(
                 question=question, 
@@ -312,7 +314,7 @@ def generate_value_suggestions(
         }
         if evidence_ids and k in evidence_ids:
             cell_value['metadata'] = {
-                "evidenceId": evidence_ids[k],
+                "evidence": evidence_ids[k],
             }
         cell_values.append(cell_value)
     
@@ -324,7 +326,7 @@ def generate_value_suggestions(
             }
             if evidence_ids and k in evidence_ids:
                 cell_value['metadata'] = {
-                    "evidenceId": evidence_ids[k],
+                    "evidence": evidence_ids[k],
                 }
             cell_values.append(cell_value)
 


### PR DESCRIPTION
This PR has the following updates to make our table generator pipeline easier to tweak for evaluation:
1. Instead of fixing column number to 10, we allow it to be variable.
2. We require both a section title + original user query, but allow passing in empty strings for original user query (in case there is only one query available).
3. We add a flag to enable or disable subselection of non-empty columns/rows as needed.
4. For vespa QA, instead of returning both answer string and evidence snippets in cell values, we push evidence into the metadata field and only returning raw answer in cell values for now.