### PR TITLE
Aps/tokens usage

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 #Help generate the rest of the file
 name = "ai2-scholar-qa"
-version = "0.6.14"
+version = "0.6.15"
 readme = "README.md"
 license = {text = 'Apache-2.0'}
 description = "Python package to embed the Ai2 Scholar QA functionality in another application"

--- a/api/scholarqa/llms/constants.py
+++ b/api/scholarqa/llms/constants.py
@@ -13,4 +13,6 @@ CompletionResult = namedtuple("CompletionCost",
 
 CostReportingArgs = namedtuple("CostReportingArgs", ["task_id", "user_id", "msg_id", "description", "model"])
 
-CostAwareLLMResult = namedtuple("CostAwareLLMResult", ["result", "tot_cost", "models"])
+TokenUsage = namedtuple("TokenUsage", ["input", "output", "total"])
+
+CostAwareLLMResult = namedtuple("CostAwareLLMResult", ["result", "tot_cost", "models", "tokens"])

--- a/api/scholarqa/llms/constants.py
+++ b/api/scholarqa/llms/constants.py
@@ -9,10 +9,10 @@ CLAUDE_37_SONNET = "anthropic/claude-3-7-sonnet-20250219"
 LLAMA_405_TOGETHER_AI = "together_ai/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo"
 
 CompletionResult = namedtuple("CompletionCost",
-                              ["content", "model", "cost", "input_tokens", "output_tokens", "total_tokens"])
+                              ["content", "model", "cost", "input_tokens", "output_tokens", "total_tokens", "reasoning_tokens"])
 
 CostReportingArgs = namedtuple("CostReportingArgs", ["task_id", "user_id", "msg_id", "description", "model"])
 
-TokenUsage = namedtuple("TokenUsage", ["input", "output", "total"])
+TokenUsage = namedtuple("TokenUsage", ["input", "output", "total", "reasoning"])
 
 CostAwareLLMResult = namedtuple("CostAwareLLMResult", ["result", "tot_cost", "models", "tokens"])

--- a/api/scholarqa/models.py
+++ b/api/scholarqa/models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Dict
 
 from nora_lib.tasks.models import AsyncTaskState as BaseAsyncTaskState
 from pydantic import BaseModel, Field
@@ -70,6 +70,7 @@ class TaskResult(BaseModel):
         description="The generated iterations of the answer"
     )
     cost: float = Field(description="The overall cost of the task", default=0.0)
+    tokens: Dict[str, int] = Field(description="The tokens used to generate the answer")
 
 
 class ToolResponse(BaseModel):

--- a/api/scholarqa/postprocess/json_output_utils.py
+++ b/api/scholarqa/postprocess/json_output_utils.py
@@ -111,7 +111,8 @@ def get_json_summary(llm_model: str, summary_sections: List[str], summary_quotes
     sections = []
     llm_name_parts = llm_model.split("/", maxsplit=1)
     llm_ref_format = f'<Model name="{llm_name_parts[0].capitalize()}" version="{llm_name_parts[1]}">'
-    inline_citation_quotes = {k: v for incite in summary_quotes.values() for k, v in
+    summary_quotes = {anyascii(k): v for k, v in summary_quotes.items()}
+    inline_citation_quotes = {anyascii(k): v for incite in summary_quotes.values() for k, v in
                               incite["inline_citations"].items()}
     for sec in summary_sections:
         curr_section = get_section_text(sec)

--- a/api/scholarqa/preprocess/query_preprocessor.py
+++ b/api/scholarqa/preprocess/query_preprocessor.py
@@ -8,7 +8,8 @@ from typing import Tuple, List, Optional, Union
 from litellm import moderation
 from pydantic import BaseModel, Field
 
-from scholarqa.llms.litellm_helper import llm_completion, CompletionResult
+from scholarqa.llms.litellm_helper import llm_completion
+from scholarqa.llms.constants import CompletionResult
 from scholarqa.llms.prompts import QUERY_DECOMPOSER_PROMPT
 
 logger = logging.getLogger(__name__)

--- a/api/scholarqa/rag/multi_step_qa_pipeline.py
+++ b/api/scholarqa/rag/multi_step_qa_pipeline.py
@@ -11,7 +11,7 @@ from scholarqa.llms.constants import GPT_4o
 from scholarqa.llms.litellm_helper import batch_llm_completion, llm_completion
 from scholarqa.llms.prompts import USER_PROMPT_PAPER_LIST_FORMAT, USER_PROMPT_QUOTE_LIST_FORMAT, \
     PROMPT_ASSEMBLE_NO_QUOTES_SUMMARY
-from scholarqa.utils import CompletionResult
+from scholarqa.llms.constants import CompletionResult
 
 logger = logging.getLogger(__name__)
 

--- a/api/scholarqa/scholar_qa.py
+++ b/api/scholarqa/scholar_qa.py
@@ -594,4 +594,4 @@ class ScholarQA:
         self.postprocess_json_output(json_summary, quotes_meta=quotes_metadata)
         event_trace.trace_summary_event(json_summary, all_sections)
         event_trace.persist_trace(self.logs_config)
-        return TaskResult(sections=generated_sections, cost=event_trace.total_cost)
+        return TaskResult(sections=generated_sections, cost=event_trace.total_cost, tokens=event_trace.tokens)

--- a/api/scholarqa/scholar_qa.py
+++ b/api/scholarqa/scholar_qa.py
@@ -426,7 +426,7 @@ class ScholarQA:
                 column_model=payload["column_model"],
                 value_model=payload["value_model"],
             )
-            tlist[dim["idx"]] = table
+            tlist[dim["idx"]] = (table, costs)
             
         task_id = self.task_id if self.task_id else self.tool_request.task_id
         payload = {
@@ -587,11 +587,18 @@ class ScholarQA:
         for tthread in table_threads:
             tthread.join()
         logger.info(f"Adhoc Table generation wait time: {time() - start:.2f}")
-
+        tcosts = []
         for sidx in range(len(json_summary)):
-            json_summary[sidx]["table"] = tables[sidx].to_dict() if tables[sidx] else None
-            generated_sections[sidx].table = tables[sidx] if tables[sidx] else None
+            tables_val = None
+            if tables[sidx]:
+                if type(tables[sidx]) == tuple:
+                    tables_val, tcost = tables[sidx]
+                    tcosts.append(tcost)
+                else:
+                    tables_val = tables[sidx]
+            json_summary[sidx]["table"] = tables_val.to_dict() if tables_val else None
+            generated_sections[sidx].table = tables_val if tables_val else None
         self.postprocess_json_output(json_summary, quotes_meta=quotes_metadata)
-        event_trace.trace_summary_event(json_summary, all_sections)
+        event_trace.trace_summary_event(json_summary, all_sections, tcosts)
         event_trace.persist_trace(self.logs_config)
         return TaskResult(sections=generated_sections, cost=event_trace.total_cost, tokens=event_trace.tokens)

--- a/api/scholarqa/state_mgmt/local_state_mgr.py
+++ b/api/scholarqa/state_mgmt/local_state_mgr.py
@@ -1,12 +1,12 @@
 import os
 from abc import ABC, abstractmethod
 from time import time
-from typing import List, Any, Optional
+from typing import List, Any, Optional, Union, Tuple
 from uuid import uuid5, UUID
 
 from nora_lib.tasks.state import IStateManager, StateManager
 
-from scholarqa.llms.constants import CompletionResult, CostReportingArgs
+from scholarqa.llms.constants import CompletionResult, CostReportingArgs, TokenUsage
 from scholarqa.models import TaskResult, TaskStep, AsyncTaskState, ToolRequest
 
 UUID_NAMESPACE = os.getenv("UUID_ENCODER_KEY", "ai2-scholar-qa")
@@ -55,8 +55,14 @@ class LocalStateMgrClient(AbsStateMgrClient):
     def get_state_mgr(self, tool_req: Optional[ToolRequest] = None) -> IStateManager:
         return self.state_mgr
 
-    def report_llm_usage(self, completion_costs: List[CompletionResult], cost_args: CostReportingArgs) -> float:
-        return sum([cost.cost for cost in completion_costs])
+    def report_llm_usage(self, completion_costs: List[CompletionResult], cost_args: CostReportingArgs) -> Union[float, Tuple[float, TokenUsage]]:
+        tot_cost = sum([cost.cost for cost in completion_costs])
+        token_usage = TokenUsage(
+            input=sum([cost.input_tokens for cost in completion_costs]),
+            output=sum([cost.output_tokens for cost in completion_costs]),
+            total=sum([cost.total_tokens for cost in completion_costs])
+        )
+        return tot_cost, token_usage
 
     def init_task(self, task_id: str, tool_request: ToolRequest):
         try:

--- a/api/scholarqa/state_mgmt/local_state_mgr.py
+++ b/api/scholarqa/state_mgmt/local_state_mgr.py
@@ -60,7 +60,8 @@ class LocalStateMgrClient(AbsStateMgrClient):
         token_usage = TokenUsage(
             input=sum([cost.input_tokens for cost in completion_costs]),
             output=sum([cost.output_tokens for cost in completion_costs]),
-            total=sum([cost.total_tokens for cost in completion_costs])
+            total=sum([cost.total_tokens for cost in completion_costs]),
+            reasoning=sum([cost.reasoning_tokens for cost in completion_costs])
         )
         return tot_cost, token_usage
 

--- a/api/scholarqa/table_generation/column_suggestion.py
+++ b/api/scholarqa/table_generation/column_suggestion.py
@@ -95,7 +95,8 @@ def generate_attribute_suggestions(
         "tokens": {
             "total": output.result.total_tokens,
             "prompt": output.result.input_tokens,
-            "completion": output.result.output_tokens
+            "completion": output.result.output_tokens,
+            "reasoning": output.result.reasoning_tokens
         },
         "model": output.result.model,
     }

--- a/api/scholarqa/table_generation/value_generation.py
+++ b/api/scholarqa/table_generation/value_generation.py
@@ -28,7 +28,8 @@ def get_cost_object(completion: CompletionResult) -> dict:
         "tokens": {
             "total": completion.total_tokens,
             "prompt": completion.input_tokens,
-            "completion": completion.output_tokens
+            "completion": completion.output_tokens,
+            "reasoning": completion.reasoning_tokens
         },
         "model": completion.model,
     }

--- a/api/scholarqa/table_generation/value_generation.py
+++ b/api/scholarqa/table_generation/value_generation.py
@@ -186,7 +186,7 @@ def run_paper_qa(
                 method=llm_completion,
                 **value_generation_params,
             )
-            print(json.loads(output.result.content))
+            # print(json.loads(output.result.content))
             response_simplified = {
                 "question": question,
                 "answer": json.loads(output.result.content)["answer"],
@@ -195,7 +195,7 @@ def run_paper_qa(
                 "evidenceId": json.loads(output.result.content).get("exceprts", []),
                 "cost": get_cost_object(output.result),
             }
-            print(response_simplified)
+            # print(response_simplified)
         else:
             response, cost = get_value_from_abstract(
                 question=question, 

--- a/api/scholarqa/trace/event_traces.py
+++ b/api/scholarqa/trace/event_traces.py
@@ -33,7 +33,7 @@ class EventTrace:
         self.cluster = dict()
         self.summary = dict()
         self.total_cost = 0.0
-        self.tokens = {"input": 0, "output": 0, "total": 0}
+        self.tokens = {"input": 0, "output": 0, "total": 0, "reasoning": 0}
 
     def trace_decomposition_event(self, decomposed_query: CostAwareLLMResult):
         self.decomposed_query = decomposed_query.result._asdict()
@@ -98,6 +98,7 @@ class EventTrace:
                     self.tokens["input"] += column_cost["tokens"]["prompt"]
                     self.tokens["output"] += column_cost["tokens"]["completion"]
                     self.tokens["total"] += column_cost["tokens"]["total"]
+                    self.tokens["reasoning"] += column_cost["tokens"].get("reasoning", 0)
 
                 cell_cost = tcost.get("cell_cost", 0.0)
                 if cell_cost:
@@ -109,6 +110,7 @@ class EventTrace:
                             self.tokens["input"] += v["tokens"]["prompt"]
                             self.tokens["output"] += v["tokens"]["completion"]
                             self.tokens["total"] += v["tokens"]["total"]
+                            self.tokens["reasoning"] += v["tokens"].get("reasoning", 0)
 
 
     def persist_trace(self, logs_config: LogsConfig):

--- a/api/scholarqa/trace/event_traces.py
+++ b/api/scholarqa/trace/event_traces.py
@@ -33,12 +33,16 @@ class EventTrace:
         self.cluster = dict()
         self.summary = dict()
         self.total_cost = 0.0
+        self.tokens = {"input": 0, "output": 0, "total": 0}
 
     def trace_decomposition_event(self, decomposed_query: CostAwareLLMResult):
         self.decomposed_query = decomposed_query.result._asdict()
         self.decomposed_query["cost"] = decomposed_query.tot_cost
         self.decomposed_query["model"] = decomposed_query.models[0]
+        self.decomposed_query["tokens"] = decomposed_query.tokens._asdict()
         self.total_cost += decomposed_query.tot_cost
+        for k,v in self.tokens.items():
+            self.tokens[k] += self.decomposed_query["tokens"][k]
 
     def trace_retrieval_event(self, retrieved: List[Dict[str, Any]]):
         self.n_retrieved = len(retrieved)
@@ -56,15 +60,21 @@ class EventTrace:
             tk["model"] = topk_models[idx]
 
         self.quotes["cost"] = paper_summaries.tot_cost
+        self.quotes["tokens"] = paper_summaries.tokens._asdict()
         self.quotes["quotes"] = topk
         self.total_cost += paper_summaries.tot_cost
+        for k, v in self.tokens.items():
+            self.tokens[k] += self.quotes["tokens"][k]
 
     def trace_clustering_event(self, cluster_json: CostAwareLLMResult, plan_str: Dict[str, Any]):
         self.cluster["cost"] = cluster_json.tot_cost
+        self.cluster["tokens"] = cluster_json.tokens._asdict()
         self.cluster["cot"] = cluster_json.result["cot"]
         self.cluster["plan"] = plan_str
         self.cluster["model"] = cluster_json.models[0]
         self.total_cost += cluster_json.tot_cost
+        for k, v in self.tokens.items():
+            self.tokens[k] += self.cluster["tokens"][k]
 
     def trace_inline_citation_following_event(self, paper_summaries_extd: Dict[str, Any], quotes_metadata: Dict[str, List[Dict[str, Any]]]):
         for quote_obj in self.quotes["quotes"]:
@@ -73,10 +83,12 @@ class EventTrace:
             quote_obj["metadata"] = quotes_metadata.get(quote_obj["key"], [])
 
     def trace_summary_event(self, json_summary: List[Dict[str, Any]], cost_result: CostAwareLLMResult):
-        self.summary = {"sections": json_summary, "cost": cost_result.tot_cost}
+        self.summary = {"sections": json_summary, "cost": cost_result.tot_cost, "tokens": cost_result.tokens._asdict()}
         for idx, section in enumerate(self.summary["sections"]):
             section["model"] = cost_result.models[idx]
         self.total_cost += cost_result.tot_cost
+        for k, v in self.tokens.items():
+            self.tokens[k] += self.summary["tokens"][k]
 
     def persist_trace(self, logs_config: LogsConfig):
         trace_writer = GCSWriter(bucket_name=logs_config.event_trace_loc) if logs_config.tracing_mode == "gcs" \

--- a/api/scholarqa/utils.py
+++ b/api/scholarqa/utils.py
@@ -17,8 +17,6 @@ logger = logging.getLogger(__name__)
 S2_APIKEY = os.getenv("S2_API_KEY", "")
 S2_HEADERS = {"x-api-key": S2_APIKEY}
 S2_API_BASE_URL = "https://api.semanticscholar.org/graph/v1/"
-CompletionResult = namedtuple("CompletionCost",
-                              ["content", "model", "cost", "input_tokens", "output_tokens", "total_tokens"])
 NUMERIC_META_FIELDS = {"year", "citationCount", "referenceCount", "influentialCitationCount"}
 CATEGORICAL_META_FIELDS = {"title", "abstract", "corpusId", "authors", "venue", "isOpenAccess", "openAccessPdf"}
 METADATA_FIELDS = ",".join(CATEGORICAL_META_FIELDS.union(NUMERIC_META_FIELDS))


### PR DESCRIPTION
Changes:
--> Return token usage (input, output and total) as part of the CostAwareLLMResult tuple
--> Write back the token usage to the json traces
--> Return cumulative token usage (sqa generation + tables) as part of the final response
--> bump up the library version

Trace S/S after change:
<img width="437" alt="image" src="https://github.com/user-attachments/assets/069580f2-16fd-4f09-abc7-c8de468e657c" />
<img width="323" alt="image" src="https://github.com/user-attachments/assets/f0f3997d-5597-4857-8390-cbe1d48359e8" />

<img width="619" alt="image" src="https://github.com/user-attachments/assets/e63cb9d4-aeab-4366-9ac0-58ee040c58ee" />

