### PR TITLE
Add missing words in examples for query decomposition

### DIFF
--- a/api/scholarqa/llms/prompts.py
+++ b/api/scholarqa/llms/prompts.py
@@ -309,8 +309,8 @@ What are the effects of climate change on agricultural productivity in Sub-Sahar
     "venues": "",
     "authors": [],
     "field_of_study": "Environmental Science,Agricultural and Food Sciences",
-    "rewritten_query": "Effects on agricultural productivity in Sub-Saharan Africa.",
-    "rewritten_query_for_keyword_search": "agricultural productivity Sub-Saharan Africa"
+    "rewritten_query": "Effects of climate change on agricultural productivity in Sub-Saharan Africa.",
+    "rewritten_query_for_keyword_search": "climate change agricultural productivity Sub-Saharan Africa"
 }
 ```
 </example output #4>  
@@ -327,8 +327,8 @@ Explore the role of neural networks in solving mathematical optimization problem
     "venues": "",
     "authors": [],
     "field_of_study": "Computer Science,Mathematics",
-    "rewritten_query": "Role in solving mathematical optimization problems.",
-    "rewritten_query_for_keyword_search": "mathematical optimization problems"
+    "rewritten_query": "Role of neural networks in solving mathematical optimization problems.",
+    "rewritten_query_for_keyword_search": "neural networks mathematical optimization problems"
 }
 ```
 </example output #5>  
@@ -345,8 +345,8 @@ Discuss the historical significance of the Renaissance period on modern art and 
     "venues": "",
     "authors": [],
     "field_of_study": "Art,Philosophy",
-    "rewritten_query": "Historical significance on modern art and philosophy.",
-    "rewritten_query_for_keyword_search": "modern art philosophy"
+    "rewritten_query": "Historical significance of Renaissance on modern art and philosophy.",
+    "rewritten_query_for_keyword_search": "Renaissance modern art philosophy"
 }
 ```
 </example output #6>  


### PR DESCRIPTION
Changed decomposition for some queries which are in a similar pattern. Examples below.

1. Query: Examine the impact of quantum computing on cryptographic security systems.
Before prompt change:
`"rewritten_query": "Impact on cryptographic security systems.",
   "keyword_query": "cryptographic security systems",`
   After prompt change:
   `"rewritten_query": "Impact of quantum computing on cryptographic security systems.",
     "keyword_query": "quantum computing cryptographic security systems"`
2. Query: Analyze the influence of the Industrial Revolution on contemporary labor movements and worker rights.
Before prompt change:
`"rewritten_query": 'Influence on contemporary labor movements and worker rights.'
  "keyword_query": "contemporary labor movements worker rights"
`
Note: This query exits with Exception: No relevant papers found for the query post reranking, skipping quote extraction.
After prompt change:
`"rewritten_query": "Influence of Industrial Revolution on contemporary labor movements and worker rights.",\n
   "keyword_query": "Industrial Revolution labor movements worker rights"`
   
 
Decomposition remains essentially the same for queries which don't face this issue before the change. Examples below:

1. Query: efficacy of mindfulness-based interventions for anxiety disorders?
Before prompt change:
`"rewritten_query": "Efficacy of mindfulness-based interventions for anxiety disorders.",
   "keyword_query": "mindfulness-based interventions anxiety disorders efficacy"`
   After prompt change:
   `    "rewritten_query": "Efficacy of mindfulness-based interventions for anxiety disorders.",
        "keyword_query": "mindfulness interventions anxiety disorders efficacy"`

2. Query: What are the consequences of urbanization on biodiversity conservation efforts in Southeast Asian megacities according to recent research?
Before prompt change:
`"rewritten_query": "Consequences of urbanization on biodiversity conservation efforts in Southeast Asian megacities.",
 "keyword_query": "urbanization biodiversity conservation Southeast Asian megacities"`
 After prompt change:
 `"rewritten_query": "Consequences of urbanization on biodiversity conservation efforts in Southeast Asian megacities.",
 "keyword_query": "urbanization biodiversity conservation Southeast Asian megacities"`