### PR TITLE
Use correct RERANKER_MAPPING key

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ class RunConfig(BaseModel):
    of retrieval/reranker you want to instantiate. Ai2 Scholar QA uses the
    `FullTextRetriever` and `ModalReranker` respectively, which are chosen based on the
    default  `public_api` and `modal` config values respectively. To choose a
-   SentenceTransformers reranker, replace `modal` with `cross_encoder` or
+   SentenceTransformers reranker, replace `modal` with `crossencoder` or
    `biencoder` or define your own types.
  
   ii. `*(retriever, reranker, paper_finder, pipeline)_args` are used to


### PR DESCRIPTION
Thanks for working on and releasing this code!

This PR updates the readme to reflect the existing key in the [RERANKER_MAPPING](https://github.com/allenai/ai2-scholarqa-lib/blob/main/api/scholarqa/rag/reranker/reranker_base.py#L86), which appears to be 'crossencoder', not 'cross_encoder'.