### PR TITLE
Aps/sqa report edit

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 #Help generate the rest of the file
 name = "ai2-scholar-qa"
-version = "0.8.12"
+version = "0.8.13"
 readme = "README.md"
 license = {text = 'Apache-2.0'}
 description = "Python package to embed the Ai2 Scholar QA functionality in another application"

--- a/api/scholarqa/edit_pipeline_runner.py
+++ b/api/scholarqa/edit_pipeline_runner.py
@@ -16,6 +16,7 @@ from scholarqa.preprocess.edit_intent_analyzer import analyze_edit_intent, EditI
 from scholarqa.rag.edit_pipeline import EditAction, EditPipeline
 from scholarqa.scholar_qa import ScholarQA
 from scholarqa.trace.event_traces import EventTrace
+from scholarqa.table_generation.table_model import TableWidget
 from scholarqa.utils import get_paper_metadata, NUMERIC_META_FIELDS, CATEGORICAL_META_FIELDS
 
 logger = logging.getLogger(__name__)
@@ -221,7 +222,7 @@ class EditPipelineRunner(ScholarQA):
                 original_query=original_query,
             )
             retrieved_candidates.extend(mentioned_candidates)
-        elif intent_analysis.needs_search:
+        if intent_analysis.needs_search:
             snippet_results, search_api_results = self._search_for_new_papers(intent_analysis)
             retrieved_candidates.extend(snippet_results + search_api_results)
 
@@ -529,7 +530,7 @@ class EditPipelineRunner(ScholarQA):
         # ====================================================================
         # STEP 1: Search and Rerank (CONDITIONAL, based on intent analysis)
         # ====================================================================
-        if intent_analysis.needs_search:
+        if intent_analysis.is_addition:
             retrieved_candidates, paper_metadata = self.find_relevant_papers_for_edit(
                 intent_analysis=intent_analysis,
                 original_query=req.query or "",
@@ -701,7 +702,7 @@ class EditPipelineRunner(ScholarQA):
         )
 
         json_summary, generated_sections, table_threads = [], [], []
-        tables = [None for _ in plan_dimensions]
+        tables = {}  # keyed by json_summary index, not plan_dimensions index
         citation_ids = dict()
         current_sections_map = {s["title"]: s for s in report_sections}
 
@@ -750,13 +751,16 @@ class EditPipelineRunner(ScholarQA):
             section_edited = action in (EditAction.REWRITE, EditAction.NEW)
             if section_json["format"] == "list" and section_json["citations"] and self.run_table_generation \
                     and (section_edited or format_changed):
-                dim["idx"] = idx
+                dim["idx"] = len(json_summary) - 1  # json_summary index, not plan index
                 cit_ids = [int(c["paper"]["corpus_id"]) for c in section_json["citations"]]
                 tthread = self.gen_table_thread(user_id, edit_instruction, dim, cit_ids, tables)
                 if tthread:
                     table_threads.append(tthread)
 
             gen_sec = self.get_gen_sections_from_json(section_json)
+            # Preserve existing table for KEEP sections (get_gen_sections_from_json doesn't copy it)
+            if action == EditAction.KEEP and section_json.get("table") is not None:
+                gen_sec.table = TableWidget.model_validate(section_json["table"])
             generated_sections.append(gen_sec)
 
         # Capture CostAwareLLMResult from generator return value
@@ -782,15 +786,18 @@ class EditPipelineRunner(ScholarQA):
 
         tcosts = []
         for sidx in range(len(json_summary)):
-            tables_val = None
-            if sidx < len(tables) and tables[sidx]:
+            if sidx in tables and tables[sidx]:
                 if type(tables[sidx]) == tuple:
                     tables_val, tcost = tables[sidx]
                     tcosts.append(tcost)
                 else:
                     tables_val = tables[sidx]
-            json_summary[sidx]["table"] = tables_val.to_dict() if tables_val else None
-            generated_sections[sidx].table = tables_val if tables_val else None
+                json_summary[sidx]["table"] = tables_val.to_dict()
+                generated_sections[sidx].table = tables_val
+            elif "table" not in json_summary[sidx]:
+                # REWRITE/NEW sections without table gen: ensure "table" key exists
+                # KEEP sections already have "table" from current_sections_map — left untouched
+                json_summary[sidx]["table"] = None
 
         self.postprocess_json_output(json_summary, quotes_meta=quotes_metadata)
 

--- a/api/scholarqa/edit_pipeline_runner.py
+++ b/api/scholarqa/edit_pipeline_runner.py
@@ -153,16 +153,17 @@ class EditPipelineRunner(ScholarQA):
         for corpus_id in paper_ids - snippet_corpus_ids:
             if corpus_id in paper_metadata:
                 candidate = dict(paper_metadata[corpus_id])
-                candidate["text"] = candidate.get("abstract", "")
-                candidate["section_title"] = "abstract"
-                candidate["char_start_offset"] = 0
-                candidate["sentence_offsets"] = []
-                candidate["ref_mentions"] = []
-                candidate["score"] = 1.0
-                candidate["stype"] = "public_api"
-                candidate["pdf_hash"] = ""
-                retrieved_candidates.append(candidate)
-                logger.info(f"Added metadata-only candidate for paper {corpus_id}")
+                if candidate.get("title") and candidate.get("abstract"):
+                    candidate["text"] = candidate.get("abstract", "")
+                    candidate["section_title"] = "abstract"
+                    candidate["char_start_offset"] = 0
+                    candidate["sentence_offsets"] = []
+                    candidate["ref_mentions"] = []
+                    candidate["score"] = 1.0
+                    candidate["stype"] = "public_api"
+                    candidate["pdf_hash"] = ""
+                    retrieved_candidates.append(candidate)
+                    logger.info(f"Added metadata-only candidate for paper {corpus_id}")
 
         return retrieved_candidates, paper_metadata
 

--- a/api/scholarqa/llms/edit/prompts.py
+++ b/api/scholarqa/llms/edit/prompts.py
@@ -59,6 +59,12 @@ User mentioned these section titles: {section_titles}
 - "Remove papers from venue X" → Look at current_citations, find papers with that venue, output their corpus_ids in papers_to_remove
 - "Remove papers before 2020" → Look at current_citations, find papers with year < 2020, output their corpus_ids in papers_to_remove
 - "Rewrite section 2" / "Fix errors" / "Shorten" → is_stylistic = true
+- "Delete the X section" / "Remove section X" → is_stylistic = false, target_sections = ["X"]. This is a STRUCTURAL change, NOT paper removal — do NOT populate papers_to_remove.
+
+**IMPORTANT — Section removal vs paper removal:**
+"Remove/delete section X" means delete the section structure. papers_to_remove must stay EMPTY.
+"Remove paper 12345" or "Remove papers before 2020" means remove specific papers. papers_to_remove should have corpus_ids.
+Do NOT confuse these two intents. Section deletion is handled by the clustering step (DELETE action), not by papers_to_remove.
 
 **Composing search_query:**
 When search is needed, combine:
@@ -114,6 +120,17 @@ Output:
 }}
 
 Example 4:
+Edit Instruction: "Remove the Related Work section"
+Output:
+{{
+  "cot": "User wants to remove an entire section. This is a structural change, not paper removal. The clustering step will assign DELETE action to this section. papers_to_remove should be empty.",
+  "search_query": "",
+  "is_stylistic": false,
+  "target_sections": ["Related Work"],
+  "affects_all_sections": false
+}}
+
+Example 5:
 Edit Instruction: "Remove papers from before 2020"
 current_citations includes: [{{"corpus_id": "111", "year": 2018}}, {{"corpus_id": "222", "year": 2021}}, {{"corpus_id": "333", "year": 2019}}]
 Output:
@@ -125,7 +142,7 @@ Output:
   "affects_all_sections": true
 }}
 
-Example 5:
+Example 6:
 Edit Instruction: "Add papers 123 and 456 to the report"
 mentioned_papers: [123, 456]
 Output:
@@ -137,40 +154,43 @@ Output:
   "affects_all_sections": true
 }}
 
-Example 6:
+Example 7:
 Original Query: "Training techniques for large language models"
 Edit Instruction: "Add recent papers on reinforcement learning to the Methods section"
 Output:
 {{
-    "cot": "User wants to add recent papers on reinforcement learning specifically to the Methods section
-. Need to search combining original query with new topic and section i.e. training methods like reinforcement learning",
-    "search_query": "LLM training methods related to reinforcement learning",
-    "earliest_search_year": "2023",
-    "is_stylistic": false,
-    "affects_all_sections": false,
-    "target_sections": ["Methods"]
-}}
-
-Example 7:
-Edit Instruction: "Remove papers by John Doe"
-Output:
-{{
-  "cot": "User wants to remove papers by author John Doe. Ppaers by John Doe in current_citations are corpus_id_1 and corpus_id_2.",
-  "search_query": "",
+  "cot": "User wants to add recent papers on reinforcement learning specifically to the Methods section. Need to search combining original query with new topic and section i.e. training methods like reinforcement learning",
+  "search_query": "LLM training methods related to reinforcement learning",
+  "earliest_search_year": "2023",
   "is_stylistic": false,
-  "papers_to_remove": ["corpus_id_1", "corpus_id_2],
-    "affects_all_sections": true
+  "affects_all_sections": false,
+  "target_sections": ["Methods"]
 }}
 
 Example 8:
+Edit Instruction: "Remove papers by John Doe"
+Output:
+{{
+  "cot": "User wants to remove papers by author John Doe. Papers by John Doe in current_citations are corpus_id_1 and corpus_id_2.",
+  "search_query": "",
+  "is_stylistic": false,
+  "papers_to_remove": ["corpus_id_1", "corpus_id_2"],
+  "affects_all_sections": true
+}}
+
+Example 9:
 Edit Instruction: "Add papers by John Doe from NeurIPS 2022"
 Output:
 {{
   "cot": "User wants to add papers by John Doe from NeurIPS 2022. Need to search combining original query with all section titles without the added constraints.",
   "search_query": "Techniques related to training large language models, specifically <section topics>",
-  "earliest_search_year": "2022", "latest_search_year": "2022",
-  "venues": ["NeurIPS"],
+  "earliest_search_year": "2022",
+  "latest_search_year": "2022",
+  "venues": "NeurIPS",
   "authors": ["John Doe"],
+  "is_stylistic": false,
+  "affects_all_sections": true
+}}
 
 </examples>
 

--- a/api/scholarqa/llms/edit/prompts.py
+++ b/api/scholarqa/llms/edit/prompts.py
@@ -263,6 +263,7 @@ NEW: Create a new section (not in current report) with some or all of the provid
 
 For sections marked KEEP, the quotes list should be empty.
 For sections marked REWRITE that incorporate new content, include the relevant quote indices.
+Do not REWRITE a section if the intent specifies paper to be added but there are no relevant paper quotes for it.
 You can also create NEW sections that weren't in the original report, but only if indicated in the instruction or intent.
 If a section has to be replaced, use DELETE for the old one and NEW for the new one, rather than REWRITE, while maintaining order.
 Think hard if a section with REWRITE or NEW action can lead to changes in subsequent sections (e.g., due to paper removals), you can mark those subsequent sections for REWRITE as well to ensure coherence.


### PR DESCRIPTION
Changes to fix issues from https://github.com/allenai/nora-issues/issues/2681#issuecomment-4040965233 and others that claude found:
i) Do not allow papers without quotes and abstracts to be used for generation in edit (replicated logic from normal flow).
ii) The criteria for further searches is now loosened to allow both specific papers and further customizes search queries based on edit instructions, instead of either of the cases.
iii) Specific papers were not being added without a customized search query, that should be fixed now - MikeD's issue from the bugbash (S/S attached in the ticket)
iv) Generated tables were not aligned with their particular sections, that is fixed now.
v) Removal of sections was sometimes being considered as removal of section papers too, that should be resolved now - Shriya's issue from bug bash (S/S attached in the ticket)

